### PR TITLE
Use protocol-relative URL to load resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
     <title>jQuery Google Map</title>
     <script src="javascripts/jquery.js"></script>
-    <script type="text/javascript" src="http://www.google.fr/jsapi"></script>
+    <script type="text/javascript" src="//www.google.fr/jsapi"></script>
     <script type="text/javascript">
         google.load("maps", "3.4", {
         	other_params: "sensor=false&language=fr"
@@ -45,7 +45,7 @@
         <h3>Installation</h3>
         <p>For using the plugin, you need to call jQuery, the Google API and the plugin file :</p>
         <pre><code>&lt;script src="javascripts/jquery.js"&gt;&lt;/script&gt;
-&lt;script type="text/javascript" src="http://www.google.fr/jsapi"&gt;&lt;/script&gt;
+&lt;script type="text/javascript" src="//www.google.fr/jsapi"&gt;&lt;/script&gt;
 &lt;script type="text/javascript"&gt;
     google.load("maps", "3.4", {
     	other_params: "sensor=false&language=fr"


### PR DESCRIPTION
To prevent the warning from browser and been blocked.