### PR TITLE
Close infowindow when another marker is clicked

### DIFF
--- a/jquery.googlemap.js
+++ b/jquery.googlemap.js
@@ -129,9 +129,12 @@ $(function() {
 								});
 
 								var map = $that.data('googleMap');
-
+                                previous_infowindow = null;
 								google.maps.event.addListener(marker, 'click', function() {
+                                    if(previous_infowindow!==null)
+                                        previous_infowindow.close(map, marker);
 									infowindow.open(map, marker);
+                                    previous_infowindow=infowindow;
 								});
 							} else if(params.url) {
 								google.maps.event.addListener(marker, 'click', function() {
@@ -196,9 +199,12 @@ $(function() {
 					});
 
 					var map = $this.data('googleMap');
-
+                    previous_infowindow = null;
 	        			google.maps.event.addListener(marker, 'click', function() {
+                            if(previous_infowindow!==null)
+                                previous_infowindow.close(map, marker);
 		        			infowindow.open(map, marker);
+                            previous_infowindow=infowindow;
 	        			});
 				} else if(params.url) {
           				google.maps.event.addListener(marker, 'click', function() {


### PR DESCRIPTION
Before, after every marker onclick, infowindow was displaying without closing already opened infowindow of another market. This is issue when there is multpile markers nearby.

Before
![before](https://user-images.githubusercontent.com/17717700/53413437-ff061100-39f1-11e9-8785-f625cc652df7.gif)

After
![after](https://user-images.githubusercontent.com/17717700/53413454-04fbf200-39f2-11e9-9d0e-7a7fed8d5e9c.gif)